### PR TITLE
Added overflow: auto to description container

### DIFF
--- a/app/assets/css/app/pages/home/player-page.css
+++ b/app/assets/css/app/pages/home/player-page.css
@@ -8,6 +8,7 @@
 .page-player .description-container {
 	margin-bottom: 10px;
 	margin-top: 7px;
+	overflow: auto;
 }
 
 .page-player .admin-panel .my-row {


### PR DESCRIPTION
to prevent words which are longer than the line width overflowing outside the edge of the container.
