### PR TITLE
Removed og:video tags as think they were incorrect.

### DIFF
--- a/app/controllers/home/player/PlayerController.php
+++ b/app/controllers/home/player/PlayerController.php
@@ -170,8 +170,6 @@ class PlayerController extends HomeBaseController {
 		$openGraphProperties[] = array("name"=> "video:release_date", "content"=> $currentMediaItem->scheduled_publish_time->toISO8601String());
 		$openGraphProperties[] = array("name"=> "og:title", "content"=> $playlist->generateEpisodeTitle($currentMediaItem));
 		$openGraphProperties[] = array("name"=> "og:image", "content"=> $openGraphCoverArtUri);
-		$openGraphProperties[] = array("name"=> "og:video", "content"=> $playlist->getMediaItemEmbedUri($currentMediaItem));
-		$openGraphProperties[] = array("name"=> "og:video:type", "content"=> "text/html");
 		if (!is_null($playlist->show)) {
 			if (!is_null($playlistNextItemUri)) {
 				$openGraphProperties[] = array("name"=> "og:see_also", "content"=> $playlistNextItemUri);


### PR DESCRIPTION
The og:type property appears to just be the type that gets inserted in the html5 video tags type property. Wish facebook had better documentation.
