### PR TITLE
Put log4Javascript into quiet mode.

### DIFF
--- a/app/assets/scripts/app/logger.js
+++ b/app/assets/scripts/app/logger.js
@@ -2,11 +2,15 @@ define([
 	"./page-data",
 	"lib/log4javascript"
 ], function(PageData, log4Javascript) {
+	
+	log4Javascript.logLog.setQuietMode(true);
+	
 	var logUri = PageData.get("logUri");
 	if (logUri === null) {
 		// no uri to log to so disable logging
 		return log4Javascript.getNullLogger();
 	}
+	
 	var logger = log4Javascript.getLogger();
 	
 	// set up the logger


### PR DESCRIPTION
Previously if an error occurred whilst it tried to set up the log, or there was an error writing a log, it would show an alert box.
