### PR TITLE
An external stream url can now be specified on a media item and this means the player will show a button to this site instead of showing the stream.

### DIFF
--- a/app/assets/css/app/components/player.css
+++ b/app/assets/css/app/components/player.css
@@ -39,15 +39,26 @@
 	background-color: #000000;
 }
 
+.player-component .ad .overlay-top {
+	top: 0;
+}
+
+.player-component .ad .overlay-bottom {
+	bottom: 0;
+}
+
 .player-component .ad .overlay {
 	position: absolute;
-	bottom: 0;
 	left: 0;
 	width: 100%;
 	background-color: rgba(0, 0, 0, 0.65);
 	overflow: auto;
 	max-height: 100%;
 	padding: 5px 0;
+}
+
+.player-component .ad .overlay .click-to-watch-btn-container {
+	padding: 10px;
 }
 
 .vjs-default-skin .vjs-big-play-button {

--- a/app/assets/scripts/app/components/player-container.js
+++ b/app/assets/scripts/app/components/player-container.js
@@ -7,7 +7,7 @@ define([
 	"lib/domReady!"
 ], function($, QualitySelectionComponent, ShareModal, PlayerController, PageData) {
 	
-	var PlayerContainer = function(playerInfoUri, registerViewCountUri, registerLikeUri, updatePlaybackTimeBaseUri, enableAdminOverride, loginRequiredMsg, embedded, autoPlay) {
+	var PlayerContainer = function(playerInfoUri, registerViewCountUri, registerLikeUri, updatePlaybackTimeBaseUri, enableAdminOverride, loginRequiredMsg, embedded, autoPlay, ignoreExternalStreamUrl) {
 
 		var self = this;
 	
@@ -71,7 +71,7 @@ define([
 		$qualitySelectionItemContainer.append(qualitySelectionComponent.getEl());
 		
 		
-		var playerController = new PlayerController(playerInfoUri, registerViewCountUri, registerLikeUri, updatePlaybackTimeBaseUri, qualitySelectionComponent, responsive, autoPlay);
+		var playerController = new PlayerController(playerInfoUri, registerViewCountUri, registerLikeUri, updatePlaybackTimeBaseUri, qualitySelectionComponent, responsive, autoPlay, ignoreExternalStreamUrl);
 		$(playerController).on("playerComponentElAvailable", function() {
 			$playerComponent = playerController.getPlayerComponentEl();
 			$container.append($playerComponent);

--- a/app/assets/scripts/app/pages/embed/player-page.js
+++ b/app/assets/scripts/app/pages/embed/player-page.js
@@ -28,9 +28,10 @@ define([
 			var loginRequiredMsg = $(this).attr("data-login-required-msg");
 			var embedded = true;
 			var autoPlay = false;
+			var ignoreExternalStreamUrl = $(this).attr("data-ignore-external-stream-url") === "1";
 		
 			// replace the player-container on the dom with the PlayerContainerComponent element when the component has loaded.
-			playerContainer = new PlayerContainer(playerInfoUri, registerViewCountUri, registerLikeUri, updatePlaybackTimeUri, enableAdminOverride, loginRequiredMsg, embedded, autoPlay);
+			playerContainer = new PlayerContainer(playerInfoUri, registerViewCountUri, registerLikeUri, updatePlaybackTimeUri, enableAdminOverride, loginRequiredMsg, embedded, autoPlay, ignoreExternalStreamUrl);
 			
 			
 			playerContainer.onLoaded(function() {

--- a/app/assets/scripts/app/pages/home/player-page.js
+++ b/app/assets/scripts/app/pages/home/player-page.js
@@ -21,9 +21,10 @@ define([
 			var enableAdminOverride = $(this).attr("data-enable-admin-override") === "1";
 			var loginRequiredMsg = $(this).attr("data-login-required-msg");
 			var autoPlay = $(this).attr("data-autoplay") === "1";
+			var ignoreExternalStreamUrl = false;
 			var embedded = false
 		
-			var playerContainer = new PlayerContainer(playerInfoUri, registerViewCountUri, registerLikeUri, updatePlaybackTimeBaseUri, enableAdminOverride, loginRequiredMsg, embedded, autoPlay);
+			var playerContainer = new PlayerContainer(playerInfoUri, registerViewCountUri, registerLikeUri, updatePlaybackTimeBaseUri, enableAdminOverride, loginRequiredMsg, embedded, autoPlay, ignoreExternalStreamUrl);
 			playerContainer.onLoaded(function() {
 				$(self).empty();
 				$(self).append(playerContainer.getEl());

--- a/app/assets/scripts/app/player-controller.js
+++ b/app/assets/scripts/app/player-controller.js
@@ -296,6 +296,7 @@ define([
 			playerComponent.setCustomMsg(data.hasStream && data.streamState === 1 ? data.streamInfoMsg : "");
 			playerComponent.showVodAvailableShortly(data.hasStream && data.streamState === 3 && data.availableOnDemand);
 			playerComponent.setStartTime(data.scheduledPublishTime !== null && (!data.hasStream || data.streamState !== 3) ? new Date(data.scheduledPublishTime*1000) : null, data.hasStream);
+			playerComponent.setExternalStreamUrl(data.hasStream ? data.externalStreamUrl : null);
 			
 			if (queuedPlayerType === "vod") {
 				// start updating the local database with the users position in the video.

--- a/app/assets/scripts/app/player-controller.js
+++ b/app/assets/scripts/app/player-controller.js
@@ -19,7 +19,7 @@ define([
 	//		called with an array of {id, name}
 	//		will be an empty array in the case of there being no video
 	
-	PlayerController = function(playerInfoUri, registerViewCountUri, registerLikeUri, updatePlaybackTimeUri, qualitiesHandler, responsive, autoPlay) {
+	PlayerController = function(playerInfoUri, registerViewCountUri, registerLikeUri, updatePlaybackTimeUri, qualitiesHandler, responsive, autoPlay, ignoreExternalStreamUrl) {
 		
 		var self = this;
 		
@@ -296,7 +296,9 @@ define([
 			playerComponent.setCustomMsg(data.hasStream && data.streamState === 1 ? data.streamInfoMsg : "");
 			playerComponent.showVodAvailableShortly(data.hasStream && data.streamState === 3 && data.availableOnDemand);
 			playerComponent.setStartTime(data.scheduledPublishTime !== null && (!data.hasStream || data.streamState !== 3) ? new Date(data.scheduledPublishTime*1000) : null, data.hasStream);
-			playerComponent.setExternalStreamUrl(data.hasStream ? data.externalStreamUrl : null);
+			if (!ignoreExternalStreamUrl) {
+				playerComponent.setExternalStreamUrl(data.hasStream ? data.externalStreamUrl : null);
+			}
 			
 			if (queuedPlayerType === "vod") {
 				// start updating the local database with the users position in the video.

--- a/app/controllers/embed/EmbedController.php
+++ b/app/controllers/embed/EmbedController.php
@@ -30,9 +30,11 @@ class EmbedController extends EmbedBaseController {
 	
 			$title = $currentMediaItem->name;
 			
-			$showHeading = !isset($_GET['showheading']) || $_GET['showheading'] === "1";
+			$showHeading = !isset($_GET['showHeading']) || $_GET['showHeading'] === "1";
+			$ignoreExternalStreamUrl = isset($_GET['ignoreExternalStreamUrl']) && $_GET['ignoreExternalStreamUrl'] === "1";
 			
 			$view->showHeading = $showHeading;
+			$view->ignoreExternalStreamUrl = $ignoreExternalStreamUrl;
 			$view->episodeTitle = $title;
 			$view->playerInfoUri = $this->getInfoUri($playlistId, $mediaItemId);
 			$view->registerViewCountUri = $this->getRegisterViewCountUri($playlistId, $mediaItemId);

--- a/app/controllers/home/admin/media/MediaController.php
+++ b/app/controllers/home/admin/media/MediaController.php
@@ -146,6 +146,7 @@ class MediaController extends MediaBaseController {
 			array("stream-being-recorded", ObjectHelpers::getProp(false, $mediaItem, "liveStreamItem", "being_recorded")?"y":""),
 			array("stream-info-msg", ObjectHelpers::getProp("", $mediaItem, "liveStreamItem", "information_msg")),
 			array("stream-stream-id", ObjectHelpers::getProp("", $mediaItem, "liveStreamItem", "liveStream", "id")),
+			array("stream-external-stream-url", ObjectHelpers::getProp("", $mediaItem, "liveStreamItem", "external_stream_url")),
 			array("related-items", json_encode(array()))
 		), !$formSubmitted);
 		
@@ -209,6 +210,7 @@ class MediaController extends MediaBaseController {
 					'stream-state'	=> array('required', 'valid_stream_state_id'),
 					'stream-info-msg'	=> array('max:500'),
 					'stream-stream-id'	=> array('valid_stream_id'),
+					'stream-external-stream-url'=> array('url'),
 					'related-items'	=> array('required', 'valid_related_items')
 				), array(
 					'name.required'		=> FormHelpers::getRequiredMsg(),
@@ -226,6 +228,7 @@ class MediaController extends MediaBaseController {
 					'stream-state.valid_stream_state_id'	=> FormHelpers::getGenericInvalidMsg(),
 					'stream-info-msg.max'	=> FormHelpers::getLessThanCharactersMsg(500),
 					'stream-stream-id.valid_stream_id'	=> FormHelpers::getInvalidStreamMsg(),
+					'stream-external-stream-url.url'	=> "This is not a valid url.",
 					'related-items.valid_related_items'	=> FormHelpers::getGenericInvalidMsg()
 				));
 				
@@ -318,6 +321,9 @@ class MediaController extends MediaBaseController {
 						else {
 							EloquentHelpers::setForeignKeyNull($mediaItemLiveStream->liveStream());
 						}
+						
+						$mediaItemLiveStream->external_stream_url = FormHelpers::nullIfEmpty($formData['stream-external-stream-url']);
+						
 					}
 					else {
 						// remove livestream model if there is one

--- a/app/controllers/home/player/PlayerController.php
+++ b/app/controllers/home/player/PlayerController.php
@@ -314,6 +314,7 @@ class PlayerController extends HomeBaseController {
 		$streamInfoMsg = $hasLiveStreamItem ? $liveStreamItem->information_msg : null;
 		$streamState = $hasLiveStreamItem ? intval($liveStreamItem->getResolvedStateDefinition()->id): null;
 		$availableOnDemand = $hasLiveStreamItem ? (boolean) $liveStreamItem->being_recorded : null;
+		$externalStreamUrl = $hasLiveStreamItem ? $liveStreamItem->external_stream_url : null;
 		$streamViewCount = $hasLiveStreamItem ? intval($liveStreamItem->view_count) : null;
 		$hasVod = $hasVideoItem;
 		$vodLive = $hasVideoItem ? $videoItem->getIsLive() : null;
@@ -380,6 +381,7 @@ class PlayerController extends HomeBaseController {
 			"streamState"				=> $streamState, // 0=pending live, 1=live, 2=stream over, null=no stream
 			"streamUris"				=> $streamUris,
 			"availableOnDemand"			=> $availableOnDemand, // true if the stream is being recorded
+			"externalStreamUrl"			=> $externalStreamUrl, // the url to the page containing the live stream if hosted externally
 			"streamViewCount"			=> $streamViewCount,
 			"hasVod"					=> $hasVod, // true if this media item has a video.
 			"vodSourceId"				=> $vodSourceId, // the id of the vod source file.

--- a/app/database/migrations/2015_01_05_152423_adding external_stream_url to media_items_live_stream.php
+++ b/app/database/migrations/2015_01_05_152423_adding external_stream_url to media_items_live_stream.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddingExternalStreamUrlToMediaItemsLiveStream extends Migration {
+
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+		Schema::table('media_items_live_stream', function(Blueprint $table)
+		{
+			$table->text("external_stream_url")->nullable();
+		});
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+		Schema::table('media_items_live_stream', function(Blueprint $table)
+		{
+			$table->dropColumn("external_stream_url");
+		});
+	}
+
+}

--- a/app/models/MediaItemLiveStream.php
+++ b/app/models/MediaItemLiveStream.php
@@ -9,7 +9,7 @@ use Event;
 class MediaItemLiveStream extends MyEloquent {
 
 	protected $table = 'media_items_live_stream';
-	protected $fillable = array('enabled', 'state_id', 'information_msg', 'being_recorded');
+	protected $fillable = array('enabled', 'state_id', 'information_msg', 'being_recorded', 'external_stream_url');
 	
 	protected static function boot() {
 		parent::boot();

--- a/app/views/embed/player.php
+++ b/app/views/embed/player.php
@@ -15,7 +15,7 @@
 <?php endif; ?>
 </div>
 <?php if ($hasVideo): ?>
-<div class="player-container-component-container" data-info-uri="<?=e($playerInfoUri);?>" data-register-view-count-uri="<?=e($registerViewCountUri);?>" data-update-playback-time-base-uri="<?=e($updatePlaybackTimeBaseUri);?>" data-login-required-msg="<?=e($loginRequiredMsg);?>" data-enable-admin-override="<?=$adminOverrideEnabled?"1":"0"?>" data-register-like-uri="<?=e($registerLikeUri);?>">
+<div class="player-container-component-container" data-info-uri="<?=e($playerInfoUri);?>" data-register-view-count-uri="<?=e($registerViewCountUri);?>" data-update-playback-time-base-uri="<?=e($updatePlaybackTimeBaseUri);?>" data-login-required-msg="<?=e($loginRequiredMsg);?>" data-enable-admin-override="<?=$adminOverrideEnabled?"1":"0"?>" data-register-like-uri="<?=e($registerLikeUri);?>" data-ignore-external-stream-url="<?=$ignoreExternalStreamUrl?"1":"0"?>">
 <?php else: ?>
 <div class="player-container-component-container">
 <?php endif; ?>

--- a/app/views/home/admin/media/edit.php
+++ b/app/views/home/admin/media/edit.php
@@ -48,6 +48,7 @@
 							<?=FormHelpers::getFormCheckInput(1, "Being Recorded For VOD", "stream-being-recorded", $form['stream-being-recorded']==="y", $formErrors);?>
 							<?=FormHelpers::getFormTxtAreaInput(1, "Information Message (Shown When Not Live) (Optional)", "stream-info-msg", $form['stream-info-msg'], $formErrors);?>
 							<?=FormHelpers::getFormSelectInput(1, "Stream", "stream-stream-id", $form['stream-stream-id'], $streamOptions, $formErrors);?>
+							<?=FormHelpers::getFormTxtInput(1, "External Stream Page Url (Optional)", "stream-external-stream-url", $form['stream-external-stream-url'], $formErrors);?>
 						</div>
 					</div>
 				</div>


### PR DESCRIPTION
You can add ignoreExternalStreamUrl=1 to the embed player url and this means the stream will be shown instead of the link. This is how you would use the embeddable player on the external site where you are hosting the stream.