### PR TITLE
View count request no longer made if in admin override mode.

### DIFF
--- a/app/assets/scripts/app/player-controller.js
+++ b/app/assets/scripts/app/player-controller.js
@@ -215,7 +215,8 @@ define([
 				playerComponent = new PlayerComponent(data.coverUri, responsive);
 				$(self).triggerHandler("playerComponentElAvailable");
 				$(playerComponent).on("play", function() {
-					if (!viewCountRegistered) {
+					if (!viewCountRegistered && !overrideModeEnabled) {
+						// register view count first time play occurs if user not in admin override mode
 						viewCountRegistered = true;
 						registerViewCount();
 					}


### PR DESCRIPTION
It is now held back until it becomes live for everyone. Any view count requests when the item is not public are ignored. This means now if admin mode has previously been enabled, and then the item goes live and the user watches it, the count will be registered. Only one view count request is sent during the lifetime of the player.