### PR TITLE
Fix so that media items not shown if in a playlist where publish time not passed

### DIFF
--- a/app/models/MediaItem.php
+++ b/app/models/MediaItem.php
@@ -386,7 +386,7 @@ class MediaItem extends MyEloquent {
 		if (!$this->enabled) {
 			return false;
 		}
-		if ($this->playlists()->accessible()->count() === 0) {
+		if ($this->playlists()->accessibleToPublic()->count() === 0) {
 			return false;
 		}
 		$sideBannerFile = $this->sideBannerFile;
@@ -406,7 +406,7 @@ class MediaItem extends MyEloquent {
 	
 	public function scopeAccessible($q) {
 		return $q->where("enabled", true)->whereHas("playlists", function($q2) {
-			$q2->accessible();
+			$q2->accessibleToPublic();
 		})->where(function($q2) {
 			$q2->has("sideBannerFile", "=", 0)
 			->orWhereHas("sideBannerFile", function($q3) {


### PR DESCRIPTION
Previously the playlist would not be shown but the media item files were still accessible. Also when logged in to the cms with the correct permission you could still see the playlist page at the url. This was intended as it means an admin can check everything is working before the page goes public but changes would need making  to make sure that the media item files aren't accessible to the public and live streams can't be advertised as live when the public have no way of getting to them.