### PR TITLE
Embeddable player now redirects to main site if not in iframe

### DIFF
--- a/app/assets/scripts/app/pages/embed/player-page.js
+++ b/app/assets/scripts/app/pages/embed/player-page.js
@@ -6,12 +6,31 @@ define([
 
 	$(".page-player").first().each(function() {
 		
-		var $pageContainer = $(this).first();
-		
+		var $pageContainer = $(this).first();	
 		var $headingContainer = $pageContainer.find(".heading-container");
+	
 		
 		$pageContainer.find(".player-container-component-container").each(function() {
+			
+			function inIframe() {
+				try {
+					return window.self !== window.top;
+				} catch (e) {
+					// fail safe
+					return true;
+				}
+			}
+			
 			var self = this;
+			
+			var siteUri = $(this).attr("data-site-uri");
+			if (!inIframe()) {
+				// this is not in an iframe. it should be
+				alert("This content is not embedded correctly.\n\nYou will now be redirected to our website instead.");
+				// redirect the user to the corresponding page on the main site
+				window.location = siteUri;
+				return;
+			}
 			
 			var playerContainer = null;
 			var $playerContainer = $(this).find(".msg-container");

--- a/app/views/embed/player.php
+++ b/app/views/embed/player.php
@@ -15,9 +15,9 @@
 <?php endif; ?>
 </div>
 <?php if ($hasVideo): ?>
-<div class="player-container-component-container" data-info-uri="<?=e($playerInfoUri);?>" data-register-view-count-uri="<?=e($registerViewCountUri);?>" data-update-playback-time-base-uri="<?=e($updatePlaybackTimeBaseUri);?>" data-login-required-msg="<?=e($loginRequiredMsg);?>" data-enable-admin-override="<?=$adminOverrideEnabled?"1":"0"?>" data-register-like-uri="<?=e($registerLikeUri);?>" data-ignore-external-stream-url="<?=$ignoreExternalStreamUrl?"1":"0"?>">
+<div class="player-container-component-container" data-site-uri="<?=e($hyperlink);?>" data-info-uri="<?=e($playerInfoUri);?>" data-register-view-count-uri="<?=e($registerViewCountUri);?>" data-update-playback-time-base-uri="<?=e($updatePlaybackTimeBaseUri);?>" data-login-required-msg="<?=e($loginRequiredMsg);?>" data-enable-admin-override="<?=$adminOverrideEnabled?"1":"0"?>" data-register-like-uri="<?=e($registerLikeUri);?>" data-ignore-external-stream-url="<?=$ignoreExternalStreamUrl?"1":"0"?>">
 <?php else: ?>
-<div class="player-container-component-container">
+<div class="player-container-component-container" data-site-uri="<?=e($hyperlink);?>">
 <?php endif; ?>
 	<div class="msg-container embed-responsive">
 		<div class="embed-responsive-item">


### PR DESCRIPTION
Means if someone puts a link to the embed url instead of actually using it with an iframe the user gets redirected to the main website instead of getting the embeddable player full screen.