### PR TITLE
Added support for live stream uris that handle their own dvr

### DIFF
--- a/app/api/transformers/MediaItemTransformer.php
+++ b/app/api/transformers/MediaItemTransformer.php
@@ -85,7 +85,7 @@ class MediaItemTransformer extends Transformer {
 					$streamUrlData = [];
 				}
 				// don't retrieve urls that support dvr
-				foreach($mediaItemLiveStream->getQualitiesWithUris("live") as $qualityWithUris) {
+				foreach($mediaItemLiveStream->getQualitiesWithUris(array("live")) as $qualityWithUris) {
 					$urls = [];
 					foreach($qualityWithUris['uris'] as $a) {
 						$urls[] = [

--- a/app/assets/scripts/app/components/player.js
+++ b/app/assets/scripts/app/components/player.js
@@ -1068,7 +1068,7 @@ define([
 			for (var i=0; i<queuedPlayerUris.length; i++) {
 				var queuedUri = queuedPlayerUris[i];
 				var uri = playerUris[i];
-				if (uri.uri !== queuedUri.uri || uri.type !== queuedUri.type) {
+				if (uri.uri !== queuedUri.uri || uri.type !== queuedUri.type || uri.uriWithDvrSupport !== queuedUri.uriWithDvrSupport) {
 					return true;
 				}
 			}

--- a/app/assets/scripts/app/components/quality-and-url-input.js
+++ b/app/assets/scripts/app/components/quality-and-url-input.js
@@ -15,7 +15,8 @@ define([
 		this.getState = function() {
 			return {
 				url: url,
-				dvr: dvr,
+				dvrBridgeServiceUrl: dvrBridgeServiceUrl,
+				nativeDvr: nativeDvr,
 				type: type,
 				support: support,
 				qualityState: qualityState
@@ -24,16 +25,18 @@ define([
 		
 		this.setState = function(state) {
 			url = state.url;
-			dvr = state.dvr;
+			dvrBridgeServiceUrl = state.dvrBridgeServiceUrl;
+			nativeDvr = state.nativeDvr;
 			type = state.type;
 			support = state.support;
 			qualityState = state.qualityState;
 			$urlEl.val(url);
-			$dvrCheckbox.prop("checked", dvr);
+			$dvrBridgeCheckbox.prop("checked", dvrBridgeServiceUrl);
+			$nativeDvrCheckbox.prop("checked", nativeDvr);
 			$typeEl.val(type);
 			$supportSelect.val(support);
 			qualityAjaxSelect.setState(qualityState);
-			onCheckboxChanged(true);
+			onDvrBridgeCheckboxChanged(true);
 			$(self).triggerHandler("stateChanged");
 		};
 		
@@ -53,7 +56,8 @@ define([
 		
 		var qualityState = null;
 		var url = null;
-		var dvr = false;
+		var dvrBridgeServiceUrl = false;
+		var nativeDvr = false;
 		var type = null;
 		var support = null;
 		
@@ -62,14 +66,20 @@ define([
 		var $qualityAjaxSelectEl = qualityAjaxSelect.getEl();
 		$qualityCol.append($qualityAjaxSelectEl);
 		$el.append($qualityCol);
-		var $urlCol = $("<div />").addClass("col-md-5");
+		var $urlCol = $("<div />").addClass("col-md-4");
 		var $urlEl = $("<input />").addClass("form-control").prop("type", "url").attr("placeholder", "Stream URL");
 		$urlCol.append($urlEl);
 		$el.append($urlCol);
-		var $dvrCol = $("<div />").addClass("col-md-1");
-		var $dvrCheckbox = $("<input />").prop("type", "checkbox");
-		$dvrCol.append($("<div />").addClass("checkbox").append($("<label />").append($dvrCheckbox).append($("<span />").text("DVR"))));
-		$el.append($dvrCol);
+		var $dvrBridgeCol = $("<div />").addClass("col-md-1");
+		var $dvrBridgeCheckbox = $("<input />").prop("type", "checkbox");
+		$dvrBridgeCol.append($("<div />").addClass("checkbox").append($("<label />").append($dvrBridgeCheckbox).append($("<span />").text("URL for DVR bridge service?"))));
+		$el.append($dvrBridgeCol);
+		var $nativeDvrCol = $("<div />").addClass("col-md-1");
+		var $nativeDvrCheckbox = $("<input />").prop("type", "checkbox");
+		var $nativeDvrCheckboxContainer = $("<div />").addClass("checkbox");
+		$nativeDvrCheckboxContainer.append($("<label />").append($nativeDvrCheckbox).append($("<span />").text("URL has native DVR support?")));
+		$nativeDvrCol.append($nativeDvrCheckboxContainer);
+		$el.append($nativeDvrCol);
 		var $typeCol = $("<div />").addClass("col-md-2");
 		var $typeEl = $("<input />").addClass("form-control").prop("type", "text").attr("placeholder", "Stream Type");
 		$typeCol.append($typeEl);
@@ -92,24 +102,34 @@ define([
 		};
 		$typeEl.on("keyup change", onTypeChanged);
 		
-		var onCheckboxChanged = function(initial) {
-			var checked = $dvrCheckbox.prop("checked");
+		var onDvrBridgeCheckboxChanged = function(initial) {
+			var checked = $dvrBridgeCheckbox.prop("checked");
 			if (checked) {
 				$typeEl.prop("readonly", true).val("application/x-mpegURL");
+				$nativeDvrCheckbox.prop("disabled", true).prop("checked", false);
+				nativeDvr = null;
+				$nativeDvrCheckboxContainer.addClass("disabled");
 			}
 			else {
 				$typeEl.prop("readonly", false);
 				if (initial !== true) {
 					$typeEl.val("");
+					$nativeDvrCheckbox.prop("disabled", false).prop("checked", false);
+					nativeDvr = false;
+					$nativeDvrCheckboxContainer.removeClass("disabled");
 				}
 			}
 			onTypeChanged();
-			if (dvr !== checked) {
-				dvr = checked;
+			if (dvrBridgeServiceUrl !== checked) {
+				dvrBridgeServiceUrl = checked;
 				$(self).triggerHandler("stateChanged");
 			}
 		};
-		$dvrCheckbox.change(onCheckboxChanged);
+		$dvrBridgeCheckbox.change(onDvrBridgeCheckboxChanged);
+		$nativeDvrCheckbox.change(function() {
+			nativeDvr = $nativeDvrCheckbox.prop("checked");
+			$(self).triggerHandler("stateChanged");
+		});
 		
 		$urlEl.on("keyup change", function() {
 			var val = $(this).val();

--- a/app/assets/scripts/app/pages/admin/live-streams-edit-page.js
+++ b/app/assets/scripts/app/pages/admin/live-streams-edit-page.js
@@ -21,7 +21,8 @@ define([
 				return qualityAndUrlInput;
 			}, {
 				url: "",
-				dvr: false,
+				dvrBridgeServiceUrl: false,
+				nativeDvr: false,
 				type: "",
 				support: "all",
 				qualityState: {id: null, text: null}

--- a/app/assets/scripts/app/player-controller.js
+++ b/app/assets/scripts/app/player-controller.js
@@ -488,7 +488,7 @@ define([
 					for(var i=0; i<chosenUris.length; i++) {
 						var current = currentUris[i];
 						var pending = chosenUris[i];
-						if (current.uri !== pending.uri || current.type !== pending.type || current.supportedDevices !== pending.supportedDevices) {
+						if (current.uri !== pending.uri || current.type !== pending.type || current.supportedDevices !== pending.supportedDevices || current.uriWithDvrSupport !== pending.uriWithDvrSupport) {
 							urisChanged = true;
 							break;
 						}

--- a/app/controllers/home/admin/livestreams/LiveStreamsController.php
+++ b/app/controllers/home/admin/livestreams/LiveStreamsController.php
@@ -211,6 +211,9 @@ class LiveStreamsController extends LiveStreamsBaseController {
 						$liveStreamUri = new LiveStreamUri(array(
 							"uri"						=> $url,
 							"dvr_bridge_service_uri"	=> $dvrBridgeServiceUri,
+							// TODO allow the user to check a box in the ui to tell the system that
+							// the url they entered supports dvr (provifing it's not a bridge service url)
+							"has_dvr"					=> $dvrBridgeServiceUri ? null : false,
 							"type"						=> $type,
 							"supported_devices"			=> $supportedDevices,
 							"enabled"					=> $support !== "none"

--- a/app/controllers/home/admin/livestreams/LiveStreamsController.php
+++ b/app/controllers/home/admin/livestreams/LiveStreamsController.php
@@ -198,7 +198,8 @@ class LiveStreamsController extends LiveStreamsBaseController {
 					foreach($urlsData as $a) {
 						$qualityDefinition = QualityDefinition::find(intval($a['qualityState']['id']));
 						$url = $a['url'];
-						$dvrBridgeServiceUri = $a['dvr'];
+						$dvrBridgeServiceUri = $a['dvrBridgeServiceUrl'];
+						$nativeDvr = $a['nativeDvr'];
 						$type = $a['type'];
 						$support = $a['support'];
 						$supportedDevices = null;
@@ -211,9 +212,7 @@ class LiveStreamsController extends LiveStreamsBaseController {
 						$liveStreamUri = new LiveStreamUri(array(
 							"uri"						=> $url,
 							"dvr_bridge_service_uri"	=> $dvrBridgeServiceUri,
-							// TODO allow the user to check a box in the ui to tell the system that
-							// the url they entered supports dvr (provifing it's not a bridge service url)
-							"has_dvr"					=> $dvrBridgeServiceUri ? null : false,
+							"has_dvr"					=> $nativeDvr,
 							"type"						=> $type,
 							"supported_devices"			=> $supportedDevices,
 							"enabled"					=> $support !== "none"

--- a/app/controllers/home/liveStream/LiveStreamController.php
+++ b/app/controllers/home/liveStream/LiveStreamController.php
@@ -86,7 +86,7 @@ class LiveStreamController extends HomeBaseController {
 		$streamUris = array();
 
 		if ($streamAccessible) {
-			foreach($liveStream->getQualitiesWithUris("live") as $qualityWithUris) {
+			foreach($liveStream->getQualitiesWithUris(array("nativeDvr", "live")) as $qualityWithUris) {
 				$streamUris[] = array(
 					"quality"	=> array(
 						"id"	=> intval($qualityWithUris['qualityDefinition']->id),

--- a/app/controllers/home/player/PlayerController.php
+++ b/app/controllers/home/player/PlayerController.php
@@ -431,7 +431,7 @@ class PlayerController extends HomeBaseController {
 		// note $liveStream is the LiveStream model which is attached to the $liveStreamItem which is a MediaItemLiveStream model.
 		if ($hasLiveStreamItem && !is_null($liveStream) && $liveStream->getIsAccessible() && ($streamState === 2 || $streamState === 3 || ($streamState === 1 && $userHasMediaItemsPermission))) {
 			$onlyDvrUris = $streamState === 3;
-			foreach($liveStreamItem->getQualitiesWithUris($onlyDvrUris ? "dvr" : "all") as $qualityWithUris) {
+			foreach($liveStreamItem->getQualitiesWithUris($onlyDvrUris ? array("dvrBridge") : array("dvrBridge", "live")) as $qualityWithUris) {
 				$streamUris[] = array(
 					"quality"	=> array(
 						"id"	=> intval($qualityWithUris['qualityDefinition']->id),

--- a/app/database/migrations/2015_09_06_005053_add has_dvr to live_stream_uris.php
+++ b/app/database/migrations/2015_09_06_005053_add has_dvr to live_stream_uris.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddHasDvrToLiveStreamUris extends Migration {
+
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+		Schema::table('live_stream_uris', function(Blueprint $table)
+		{
+			$table->boolean("has_dvr")->nullable();
+		});
+		$this->setDefaultValues();
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+		Schema::table('live_stream_uris', function(Blueprint $table)
+		{
+			$table->dropColumn("has_dvr");
+		});
+	}
+
+	private function setDefaultValues() {
+		DB::table('live_stream_uris')->where('dvr_bridge_service_uri', false)->update(["has_dvr" => false]);
+	}
+
+}

--- a/app/helpers/reorderableList/StreamUrlsReorderableList.php
+++ b/app/helpers/reorderableList/StreamUrlsReorderableList.php
@@ -8,7 +8,7 @@ class StreamUrlsReorderableList implements ReorderableList {
 	private $initialDataString = null;
 	private $stringForInput = null;
 	
-	// $data should be the an array of {qualityDefinition: {id, text}, url, dvr, support, type}
+	// $data should be the an array of {qualityDefinition: {id, text}, url, dvrBridgeServiceUrl, nativeDvr, support, type}
 	// will be handled if this is not the format of the data, and obviously flagged as invalid
 	// does not need to be valid. Anything invalid will be ignored.
 	public function __construct($data) {
@@ -84,21 +84,36 @@ class StreamUrlsReorderableList implements ReorderableList {
 				$currentItemOutput["type"] = $a['type'];
 			}
 			
-			if (!isset($a['dvr']) && !is_bool($a['dvr'])) {
+			if (!isset($a['dvrBridgeServiceUrl']) || !is_bool($a['dvrBridgeServiceUrl'])) {
 				$this->valid = false;
-				$currentItemOutput["dvr"] = false;
+				$currentItemOutput["dvrBridgeServiceUrl"] = false;
 			}
 			else {
-				$currentItemOutput["dvr"] = $a['dvr'];
+				$currentItemOutput["dvrBridgeServiceUrl"] = $a['dvrBridgeServiceUrl'];
 			}
 			
 			// type must be this if using dvr bridge service as this is the type the dvr bridge service uses
-			if ($currentItemOutput["dvr"] && $currentItemOutput["type"] !== "application/x-mpegURL") {
+			if ($currentItemOutput["dvrBridgeServiceUrl"] && $currentItemOutput["type"] !== "application/x-mpegURL") {
 				$this->valid = false;
 			}
+			$currentItemOutput["dvrBridgeServiceUrl"] = isset($a['dvrBridgeServiceUrl']) && $a['dvrBridgeServiceUrl'] === true;
 			
-			$currentItemOutput["dvr"] = isset($a['dvr']) && $a['dvr'] === true;
-			
+			if ($currentItemOutput["dvrBridgeServiceUrl"]) {
+				if (!array_key_exists('nativeDvr', $a) || !is_null($a['nativeDvr'])) {
+					$this->valid = false;
+				}
+				$currentItemOutput["nativeDvr"] = null;
+			}
+			else {
+				if (!array_key_exists('nativeDvr', $a) || !is_bool($a['nativeDvr'])) {
+					$this->valid = false;
+					$currentItemOutput["nativeDvr"] = false;
+				}
+				else {
+					$currentItemOutput["nativeDvr"] = $a['nativeDvr'];
+				}
+			}
+
 			if (!isset($a["support"]) || ($a["support"] !== "all" && $a["support"] !== "pc" && $a["support"] !== "mobile" && $a["support"] !== "none")) {
 				$this->valid = false;
 				$currentItemOutput["support"] = "all";

--- a/app/models/LiveStream.php
+++ b/app/models/LiveStream.php
@@ -179,7 +179,8 @@ class LiveStream extends MyEloquent {
 						"text"	=> $a['qualityDefinition']->name
 					),
 					"url"		=> $b['uri'],
-					"dvr"		=> $b['uriForDvrBridgeService'],
+					"dvrBridgeServiceUrl"	=> $b['uriForDvrBridgeService'],
+					"nativeDvr"	=> $b['hasDvr'],
 					"type"		=> $b['type'],
 					"support"	=> $support
 				);

--- a/app/models/LiveStream.php
+++ b/app/models/LiveStream.php
@@ -56,11 +56,13 @@ class LiveStream extends MyEloquent {
 					"uris"				=> array()
 				);
 			}
+
+			$uriForDvrBridgeService = (boolean) $a->dvr_bridge_service_uri;
 			
 			$uri = array(
 				"uri"	=> $a->uri,
-				"uriForDvrBridgeService"	=> (boolean) $a->dvr_bridge_service_uri,
-				"uriFromDvrBridgeService"	=> $a->uri_from_dvr_bridge_service,
+				"uriForDvrBridgeService"	=> $uriForDvrBridgeService,
+				"hasDvr"	=> $uriForDvrBridgeService ? null : (boolean) $a->has_dvr,
 				"type"	=> $a->type,
 				"supportedDevices"	=> $a->supported_devices,
 				"enabled"	=> (boolean) $a->enabled,
@@ -74,19 +76,34 @@ class LiveStream extends MyEloquent {
 		return $qualities;
 	}
 	
-	// $filter can be "all", "dvr", "live"
-	public function getQualitiesWithUris($filter="all", $mediaItemLiveStream=null) {
-		if ($filter !== "all" && $filter !== "dvr" && $filter !== "live") {
-			throw(new Exception("Filter is not valid."));
+	// $filters is array of "dvrBridge", "nativeDvr", or "live"
+	// "dvrBridge" will return all urls which have been created by the dvr bridge service for the provided $mediaItemLiveStream
+	// "nativeDvr" will return all urls which point to streams which provide dvr functionality
+	// "live" will return all urls which point to streams which do not provide dvr functionality
+	public function getQualitiesWithUris($filters=null, $mediaItemLiveStream=null) {
+		$validFilters = array("dvrBridge", "nativeDvr", "live");
+		if (is_null($filters)) {
+			$filters = array("dvrBridge", "live");
 		}
-		
-		if (($filter === "all" || $filter === "dvr") && is_null($mediaItemLiveStream)) {
-			throw("MediaItemLiveStream model required if retrieving dvr urls.");
+
+		if (!is_array($filters)) {
+			throw new Exception("filters must be an array.");
+		}
+
+		foreach($filters as $a) {
+			if (!in_array($a, $validFilters)) {
+				throw new Exception("Unrecognised filter.");
+			}
+		}
+
+		if (in_array("dvrBridge", $filters) && is_null($mediaItemLiveStream)) {
+			throw new Exception("MediaItemLiveStream model required if retrieving dvr bridge service urls.");
 		}
 		
 		$qualities = array();
 		$urisOrganisedByQuality = $this->getUrisOrganisedByQuality();
 		foreach($urisOrganisedByQuality as $quality) {
+
 			$entry = array(
 				"qualityDefinition"	=> $quality["qualityDefinition"],
 				"uris"				=> array()
@@ -99,17 +116,25 @@ class LiveStream extends MyEloquent {
 				
 				// if the url is a url for a dvr bridge service then the url the user gets will be the url it returns
 				// the url it returns will be a hls url with dvr support.
-				$uriWithDvrSupport = $uriAndInfo['uriForDvrBridgeService'];
+				$uriForDvrBridgeService = $uriAndInfo['uriForDvrBridgeService'];
+				$uriWithDvrSupport = $uriForDvrBridgeService || $uriAndInfo["hasDvr"];
 				// if a dvr bridge service is being used then the url it provides will be placed in uri_from_dvr_bridge_service
 				// this may be null if there's been an error, in which case the user should not see it
 				$uri = null;
-				if(!$uriWithDvrSupport) {
-					$uri = $uriAndInfo['uri'];
+				if(!$uriForDvrBridgeService) {
+					if (in_array("nativeDvr", $filters) && $uriWithDvrSupport) {
+						$uri = $uriAndInfo['uri'];
+					}
+					else if (in_array("live", $filters) && !$uriWithDvrSupport) {
+						$uri = $uriAndInfo['uri'];
+					}
 				}
-				else if ($filter === "all" || $filter === "dvr") {
-					$dvrLiveStreamUriModel = $uriAndInfo["liveStreamUriModel"]->dvrLiveStreamUris()->where("dvr_live_stream_uris.media_item_live_stream_id", $mediaItemLiveStream->id)->first();
-					if (!is_null($dvrLiveStreamUriModel)) {
-						$uri = $dvrLiveStreamUriModel->uri;
+				else {
+					if (in_array("dvrBridge", $filters)) {
+						$dvrLiveStreamUriModel = $uriAndInfo["liveStreamUriModel"]->dvrLiveStreamUris()->where("dvr_live_stream_uris.media_item_live_stream_id", intval($mediaItemLiveStream->id))->first();
+						if (!is_null($dvrLiveStreamUriModel)) {
+							$uri = $dvrLiveStreamUriModel->uri;
+						}
 					}
 				}
 				
@@ -117,17 +142,12 @@ class LiveStream extends MyEloquent {
 					continue;
 				}
 				
-				if (($filter === "dvr" && !$uriWithDvrSupport) || ($filter === "live" && $uriWithDvrSupport)) {
-					continue;
-				}
-			
 				$entry['uris'][] = array(
 					"uri"	=> $uri,
 					"uriWithDvrSupport"	=> $uriWithDvrSupport,
 					"type"	=> $uriAndInfo['type'],
 					"supportedDevices"	=> $uriAndInfo['supportedDevices']
 				);
-			
 			}
 			
 			if (count($entry["uris"]) > 0) {

--- a/app/models/LiveStreamUri.php
+++ b/app/models/LiveStreamUri.php
@@ -1,9 +1,24 @@
 <?php namespace uk\co\la1tv\website\models;
 
+use Exception;
+
 class LiveStreamUri extends MyEloquent {
 	
 	protected $table = 'live_stream_uris';
-	protected $fillable = array('uri', 'dvr_bridge_service_uri', 'type', 'supported_devices', 'enabled');
+	protected $fillable = array('uri', 'dvr_bridge_service_uri', 'has_dvr', 'type', 'supported_devices', 'enabled');
+
+	protected static function boot() {
+		parent::boot();
+		self::saving(function($model) {
+			if ($model->dvr_bridge_service_uri && !is_null($model->has_dvr)) {
+				throw new Exception("has_dvr must be null if it's a dvr bridge service uri.");
+			}
+			else if (!$model->dvr_bridge_service_uri && is_null($model->has_dvr)) {
+				throw new Exception("has_dvr must not be null if it's not a dvr bridge service uri.");
+			}
+			return true;
+		});
+	}
 
 	public function qualityDefinition() {
 		return $this->belongsTo(self::$p.'QualityDefinition', 'quality_definition_id');

--- a/app/models/MediaItemLiveStream.php
+++ b/app/models/MediaItemLiveStream.php
@@ -221,17 +221,12 @@ class MediaItemLiveStream extends MyEloquent {
 		return !$this->exists || $this->getOriginal("live_stream_id") !== $this->live_stream_id;
 	}
 	
-	// $filter can be "all", "dvr", "live"
-	public function getQualitiesWithUris($filter="all") {
-		if ($filter !== "all" && $filter !== "dvr" && $filter !== "live") {
-			throw(new Exception("Filter is not valid."));
-		}
-		
+	public function getQualitiesWithUris($filters=null) {
 		$liveStreamModel = $this->liveStream;
 		if (is_null($liveStreamModel)) {
 			return array();
 		}
-		return $liveStreamModel->getQualitiesWithUris($filter, $this);
+		return $liveStreamModel->getQualitiesWithUris($filters, $this);
 	}
 	
 	// returns an array containing all the domains that live streams come from which are loaded from a http request. I.e. playlist.m3u8 for mobiles.
@@ -240,7 +235,7 @@ class MediaItemLiveStream extends MyEloquent {
 			$uris = array();
 			$models = self::get();
 			foreach($models as $a) {
-				foreach($a->getQualitiesWithUris() as $b) {
+				foreach($a->getQualitiesWithUris(array("live", "nativeDvr", "dvrBridge")) as $b) {
 					foreach($b['uris'] as $uri) {
 						$uris[] = $uri['uri'];
 					}


### PR DESCRIPTION
E.g a wowza url with ?dvr on the end. This means wowza will provide dvr functionality itself.

The system needs to know whether a url has native dvr because this should not be used for a specific media item as it may allow the user to rewind past the beginning of the show. In this case the system will provide urls from the dvr bridge service, which will be a recording from the start of the show, or urls that do not have native dvr.