### PR TITLE
Live streams can now be previewed in CMS even if not marked as live

### DIFF
--- a/app/controllers/home/admin/livestreams/LiveStreamsController.php
+++ b/app/controllers/home/admin/livestreams/LiveStreamsController.php
@@ -82,21 +82,18 @@ class LiveStreamsController extends LiveStreamsBaseController {
 	
 		$streamAccessible = $liveStream->getIsAccessible();
 		$streamUris = null;
-		if ($streamAccessible) {
-			$streamUris = array();
-			foreach($liveStream->getQualitiesWithUris(array("live", "nativeDvr")) as $qualityWithUris) {
-				$streamUris[] = array(
-					"quality"	=> array(
-						"id"	=> intval($qualityWithUris['qualityDefinition']->id),
-						"name"	=> $qualityWithUris['qualityDefinition']->name
-					),
-					"uris"		=> $qualityWithUris['uris']
-				);
-			}
-			
-			$streamUris = json_encode($streamUris);
+		$streamUris = array();
+		foreach($liveStream->getQualitiesWithUris(array("live", "nativeDvr")) as $qualityWithUris) {
+			$streamUris[] = array(
+				"quality"	=> array(
+					"id"	=> intval($qualityWithUris['qualityDefinition']->id),
+					"name"	=> $qualityWithUris['qualityDefinition']->name
+				),
+				"uris"		=> $qualityWithUris['uris']
+			);
 		}
-	
+		
+		$streamUris = json_encode($streamUris);
 	
 		$view = View::make('home.admin.livestreams.player');
 		$view->streamName = $streamName;

--- a/app/views/home/admin/livestreams/player.php
+++ b/app/views/home/admin/livestreams/player.php
@@ -4,10 +4,9 @@
 	</div>
 	<div class="panel-body">
 		<?php if (!$streamAccessible): ?>
-			<div class="alert alert-info" role="alert"><span class="glyphicon glyphicon-info-sign"></span> This stream is currently not accessible.</div>
-		<?php else: ?>
-			<div class="player-container" data-cover-art-uri="<?=e($coverArtUri)?>" data-stream-uris="<?=e($streamUris)?>"></div>
+		<div class="alert alert-danger" role="alert"><span class="glyphicon glyphicon-info-sign"></span> This stream is currently not accessible on the site. It needs to be marked as being live.</div>
 		<?php endif; ?>
+		<div class="player-container" data-cover-art-uri="<?=e($coverArtUri)?>" data-stream-uris="<?=e($streamUris)?>"></div>
 	</div>
 	<div class="panel-footer clearfix">
 		<div class="pull-left">


### PR DESCRIPTION
This means you can check a stream is working before actually marking it as live.