### PR TITLE
Implemented SynchronizedRepository, created "redisSynchronized" cache driver

### DIFF
--- a/app/config/cache.php
+++ b/app/config/cache.php
@@ -15,7 +15,8 @@ return array(
 	|
 	*/
 
-	'driver' => 'memcached',
+	// loaded in filters.php
+	'driver' => 'redisSynchronized',
 
 	/*
 	|--------------------------------------------------------------------------

--- a/app/extensions/cache/SynchronizedRepository.php
+++ b/app/extensions/cache/SynchronizedRepository.php
@@ -1,0 +1,82 @@
+<?php namespace uk\co\la1tv\website\extensions\cache;
+
+use Illuminate\Cache\Repository;
+use malkusch\lock\mutex\PredisMutex;
+use Closure;
+use Redis;
+
+/*
+ * Ensures that the "remember" and "rememberForever" methods are synchronized, so that the
+ * cache can only be updated by one process at once. Once the cache
+ * has updated if there are other processes waiting they will get
+ * the cached value.
+ */
+class SynchronizedRepository extends Repository {
+
+	/**
+	 * Get an item from the cache, or store the default value.
+	 *
+	 * @param  string  $key
+	 * @param  \DateTime|int  $minutes
+	 * @param  \Closure  $callback
+	 * @return mixed
+	 */
+	public function remember($key, $minutes, Closure $callback)
+	{
+		// timeout after 20 seconds
+		$lockKey = "SynchronizedRepository.lockKey.".$key;
+		$mutex = new PredisMutex([Redis::connection()], $lockKey, 20);
+
+		$value = null;
+
+		$mutex->check(function() use (&$value, &$key) {
+			// If the item exists in the cache we will just return this immediately
+			// otherwise we will execute the given Closure and cache the result
+			// of that execution for the given number of minutes in storage.
+			$value = $this->get($key);
+
+			// return true (meaning cache should be updated), if value not in cache
+			// if true is returned then a lock will be obtained, this will run again,
+			// and if true is returned again at this point, the "then" callback will run
+			// and the cache will be updated
+			return is_null($value);
+		})->then(function() use (&$value, &$key, &$minutes, &$callback) {
+			$this->put($key, $value = $callback(), $minutes);
+		});
+
+		return $value;
+	}
+
+	/**
+	 * Get an item from the cache, or store the default value forever.
+	 *
+	 * @param  string   $key
+	 * @param  \Closure  $callback
+	 * @return mixed
+	 */
+	public function rememberForever($key, Closure $callback)
+	{
+		// timeout after 20 seconds
+		$lockKey = "SynchronizedRepository.lockKey.".$key;
+		$mutex = new PredisMutex([Redis::connection()], $lockKey, 20);
+
+		$value = null;
+
+		$mutex->check(function() use (&$value, &$key) {
+			// If the item exists in the cache we will just return this immediately
+			// otherwise we will execute the given Closure and cache the result
+			// of that execution forever
+			$value = $this->get($key);
+
+			// return true (meaning cache should be updated), if value not in cache
+			// if true is returned then a lock will be obtained, this will run again,
+			// and if true is returned again at this point, the "then" callback will run
+			// and the cache will be updated
+			return is_null($value);
+		})->then(function() use (&$value, &$key, &$callback) {
+			$this->forever($key, $value = $callback());
+		});
+
+		return $value;
+	}
+}

--- a/app/filters.php
+++ b/app/filters.php
@@ -1,5 +1,6 @@
 <?php
-
+use Illuminate\Cache\RedisStore;
+use uk\co\la1tv\website\extensions\cache\SynchronizedRepository;
 use uk\co\la1tv\website\serviceProviders\apiAuth\exceptions\ApiException;
 use uk\co\la1tv\website\serviceProviders\apiAuth\exceptions\ApiNotAuthenticatedException;
 
@@ -15,6 +16,12 @@ use uk\co\la1tv\website\serviceProviders\apiAuth\exceptions\ApiNotAuthenticatedE
 */
 App::before(function($request)
 {
+	// add the redisSynchronized driver
+	Cache::extend('redisSynchronized', function($app) {
+		$redis = $app['redis'];
+		return new SynchronizedRepository(new RedisStore($redis, $app['config']['cache.prefix']));
+	});
+
 	// determine if degraded mode should be enabled
 	if (Redis::get("fileStoreUnavailable")) {
 		// automatically enable if filestore not accessible

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
 			"app/database/migrations",
 			"app/database/seeds",
 			"app/helpers",
+			"app/extensions",
 			"app/tests/TestCase.php"
 		]
 	},


### PR DESCRIPTION
This cache driver is now used instead of memcached. It's "remember" and "rememberForever" methods have synchronization to ensure that there is only one process trying to update the cache at once.

Refs #780 
(Closes #803)