### PR TITLE
Filestore check can now only happen once at a time, and default to assuming down

### DIFF
--- a/app/filters.php
+++ b/app/filters.php
@@ -14,18 +14,6 @@ use uk\co\la1tv\website\serviceProviders\apiAuth\exceptions\ApiNotAuthenticatedE
 */
 App::before(function($request)
 {
-	// determine if degraded mode should be enabled
-	if (Redis::get("fileStoreUnavailable")) {
-		// automatically enable if filestore not accessible
-		// this key in redis is set in the CheckFileStoreAvailability command
-		Config::set('degradedService.enabled', true);
-	}
-
-	if (Config::get('degradedService.enabled')) {
-		// if degradedService is enabled disable search (thumbnail urls incorrect)
-		Config::set('search.enabled', false);
-	}
-
 	App::error(function(ApiException $exception) {
 		return App::make('uk\co\la1tv\website\controllers\api\v1\ApiController')->callAction("respondServerError", array());
 	});


### PR DESCRIPTION
When it goes down the `file_exists` command can take a few minutes to complete and realise it's gone. Now if it hangs the redis key will expire meaning down is assumed.