### PR TITLE
Enable 'native' mobile web apps

### DIFF
--- a/app/views/layouts/base.blade.php
+++ b/app/views/layouts/base.blade.php
@@ -5,6 +5,8 @@
 		<meta charset="utf-8">
 		<title><?=$title?></title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no">
+		<meta name="apple-mobile-web-app-capable" content="yes">
+		<meta name="mobile-web-app-capable" content="yes">
 		<?php if (isset($description)): ?>
 		<meta name="description" content="<?=e($description)?>">
 		<?php endif; ?>

--- a/app/views/layouts/base.blade.php
+++ b/app/views/layouts/base.blade.php
@@ -5,7 +5,6 @@
 		<meta charset="utf-8">
 		<title><?=$title?></title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no">
-		<meta name="apple-mobile-web-app-capable" content="yes">
 		<meta name="mobile-web-app-capable" content="yes">
 		<?php if (isset($description)): ?>
 		<meta name="description" content="<?=e($description)?>">


### PR DESCRIPTION
This means apps when 'added to home screen' on Android or iOS will open as if they are a native app, without opening the browser or having the address bar.

This is fine, because you can't get into any dead ends on the site. Also, all 'external' referrals open in the native browser