### PR TITLE
Add index to created_at field in playback_history table

### DIFF
--- a/app/database/migrations/2015_09_21_225552_creating playback_history table.php
+++ b/app/database/migrations/2015_09_21_225552_creating playback_history table.php
@@ -27,6 +27,9 @@ class CreatingPlaybackHistoryTable extends Migration {
 			$table->timestamps();
 			
 			$table->index("original_session_id");
+			// when watching now count by media item is calcuulated, it is filtered by entries > created_at
+			// Without the index this query will look at all rows
+			$table->index("created_at");
 			$table->foreign("session_id")->references('id')->on('sessions')->onUpdate("restrict")->onDelete('set null');
 			$table->foreign("user_id")->references('id')->on('site_users')->onUpdate("restrict")->onDelete('set null');
 			$table->foreign("media_item_id")->references('id')->on('media_items')->onUpdate("restrict")->onDelete('cascade');


### PR DESCRIPTION
When watching now count by media item is calculated, it is filtered by entries > created_at
Without the index this query will look at all rows
There are currently 6,110,915 rows.

This should be a new migration, but that would mean I would need to get the site running locally again and I'm lazy, and having/not having this index shouldn't effect development