### PR TITLE
add composite index to playback_history

### DIFF
--- a/app/database/migrations/2020_06_18_190800_add_playback_history_composite_index.php
+++ b/app/database/migrations/2020_06_18_190800_add_playback_history_composite_index.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddPlaybackHistoryCompositeIndex extends Migration {
+
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+		Schema::table('playback_history', function(Blueprint $table)
+		{
+			$table->index(array('constitutes_view', 'media_item_id', 'type'));
+		});
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+		Schema::table('playback_history', function(Blueprint $table)
+		{
+			$table->dropIndex('playback_history_constitutes_view_media_item_id_type_index');
+		});
+	}
+
+}


### PR DESCRIPTION
Significantly improves the performance of the playback count query when there are a lot of records.

```
select count(*) as aggregate from `playback_history` where `type` = 'vod' and `media_item_id` = '407' and `constitutes_view` = '1'
```

goes from 23.64s to 0.01s.
